### PR TITLE
Add update_interval configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ This is a custom [Home Assistant](https://home-assistant.io/) component to suppo
 
 **Home Assistant 0.86 or higher is required**.
 
-Eventually this custom component will be PR'd and (hopefully) merged into Home Assistant. I'm publishing it as a custom component now for testing and feedback.
-
 For each camera in a Kuna account, the following devices will be created:
 
 - Binary Sensor with device class 'motion', and default name "[Camera Name] Motion".
@@ -14,7 +12,7 @@ For each camera in a Kuna account, the following devices will be created:
 
 Note:
 
-- The private Kuna API only supports polling (and this component polls every 15 seconds). There may therefore be a lag between when motion is detected or the light is turned on manually and the change is reflected in the Home Assistant UI.
+- The private Kuna API only supports polling. There may therefore be a lag between when motion is detected or the light is turned on manually and the change is reflected in the Home Assistant UI.
 - Entities may be renamed from the Home Assistant UI.
 - State attributes will be added to entities eventually.
 
@@ -32,7 +30,7 @@ Now, proceed with configuration.
 
 ## Configuration
 
-Add the following to `configuration.yaml`:
+Add the following minimum configuration to `configuration.yaml`:
 
 ```
 kuna:
@@ -40,7 +38,11 @@ kuna:
   password: YOUR_PASSWORD
 ```
 
-Where YOUR_EMAIL and YOUR_PASSWORD are the credentials you use to log into the Kuna mobile app.
+| Config Parameter | Optional/Required | Default | Description |
+|------------------|-------------------|---------|-------------|
+| email            | Required          | N/A     | The email address used to log into the Kuna app. |
+| password         | Required          | N/A     | The password used to log into the Kuna app. |
+| update_interval  | Optional          | 15      | The frequency, in seconds, that the component polls the Kuna server for updates. |
 
 ## Updating
 
@@ -50,4 +52,4 @@ To update the custom component, cd into the `custom_components/kuna` directory a
 
 This component has only been tested with a Maximus Smart Light. Testing and feedback by users with other (and multiple!) Kuna devices would be much appreciated!
 
-This custom component retrieves data from the same private API used by the Kuna mobile app, as Kuna does not offer a public API. It tries to be gentle to the API by polling for changes for the whole account only once every 15 seconds. Use at your own risk!
+This custom component retrieves data from the same private API used by the Kuna mobile app, as Kuna does not offer a public API. Be gentle to the API and use at your own risk!


### PR DESCRIPTION
Allow the user to control how often the component polls the Kuna API by using the update_interval paramter in configuration.yaml. Default = 15.