### PR TITLE
Bugfix: Add version key to manifest.json

### DIFF
--- a/custom_components/kuna/manifest.json
+++ b/custom_components/kuna/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://github.com/marthoc/kuna",
   "dependencies": [],
   "codeowners": ["@marthoc"],
-  "requirements": ["pykuna==0.6.0"]
+  "requirements": ["pykuna==0.6.0"],
+  "version": "9.1.0"
 }

--- a/custom_components/kuna/manifest.json
+++ b/custom_components/kuna/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": [],
   "codeowners": ["@marthoc"],
   "requirements": ["pykuna==0.6.0"],
-  "version": "9.1.0"
+  "version": "9.2"
 }


### PR DESCRIPTION
As required in HA 2021.6, added a version field to manifest.json.

Fixes #31. Fixes #33. Fixes #35.