### PR TITLE
9.2

### DIFF
--- a/custom_components/kuna/manifest.json
+++ b/custom_components/kuna/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://github.com/marthoc/kuna",
   "dependencies": [],
   "codeowners": ["@marthoc"],
-  "requirements": ["pykuna==0.6.0"]
+  "requirements": ["pykuna==0.6.0"],
+  "version": "9.2"
 }


### PR DESCRIPTION
* Add version to manifest

As required in HA 2021.6, added a version field to manifest.json.

* Bump version to 9.2 for new release including the bugfix

Co-authored-by: Mark Coombes <mark@markcoombes.ca>