### PR TITLE
Update for Home Assistant 2025.6+

### DIFF
--- a/custom_components/kuna/__init__.py
+++ b/custom_components/kuna/__init__.py
@@ -69,10 +69,9 @@ async def async_setup_entry(hass, entry):
 
     hass.data[DOMAIN] = kuna
 
-    for component in KUNA_COMPONENTS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setups(entry, KUNA_COMPONENTS)
+    )
 
     async_track_time_interval(hass, kuna.update, update_interval)
 


### PR DESCRIPTION
I updated the init to match the current instructions/examples, replacing async_forward_entry_setup async_forward_entry_setups - power to the plural https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

camera.py's async_camera_image now passes empty width, height and byte size https://developers.home-assistant.io/docs/core/entity/camera/#methods to match parameter count. I also added some logging to figure this out, which I left in.

Tested with 2025.7.1

Thanks for your work creating this!